### PR TITLE
Set database in code

### DIFF
--- a/variable_location_in_ICCA.sql
+++ b/variable_location_in_ICCA.sql
@@ -17,6 +17,9 @@
 -- Tables beginning 'D_' are definition tables and define certain concepts (e.g. D_Intervetions).
 -- The substantive patient data about these concepts are stored in fact tables (e.g. PtAssessment). 
 
+-- Set database
+USE CISReportingDB
+
 -- Table types can be viewed like this:
 SELECT * FROM dbo.M_TableType
 


### PR DESCRIPTION
Hiya,

Not really an issue-issue, but the SQL applications used typically default to a "master" database, which is then manually set to "CISReportingDB" in the GUI to make the rest of the code work.

I feel like it would be more elegant to do this in code is all.  Apologies if this a silly change or something.

All the best,
Emma